### PR TITLE
MTD-02[DevOps]:Adding-ACM

### DIFF
--- a/acm_service.tf
+++ b/acm_service.tf
@@ -1,0 +1,35 @@
+module "acm_service" {
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> 5.1.0"
+
+  domain_name = local.domain
+  zone_id     = local.zone_id
+
+  subject_alternative_names = [
+    "www.${local.domain}",
+    "api.${local.domain}",
+    "app.${local.domain}"
+  ]
+
+  create_route53_records  = false
+  validation_method       = "DNS"
+  validation_record_fqdns = cloudflare_dns_record.dns_record_validation[*].name
+
+  tags = merge(module.tags.tages, {
+    Name = local.domain
+  })
+}
+
+resource "cloudflare_dns_record" "dns_record_validation" {
+  count = length(module.acm_service.distinct_domain_names)
+
+  zone_id = local.cloudflare_zone_id
+  name    = trimsuffix(element(module.acm_service.validation_domains, count.index)["resource_record_name"], ".")
+  type    = element(module.acm_service.validation_domains, count.index)["resource_record_type"]
+  ttl     = 300
+
+  content = trimsuffix(element(module.acm_service.validation_domains, count.index)["resource_record_name"], ".")
+  comment = "ACM DNS validation for ${local.domain} - ${element(module.acm_service.validation_domains, count.index)["resource_record_type"]}"
+
+  proxied = false
+}

--- a/aws/acm_service.tf
+++ b/aws/acm_service.tf
@@ -15,7 +15,7 @@ module "acm_service" {
   validation_method       = "DNS"
   validation_record_fqdns = cloudflare_dns_record.dns_record_validation[*].name
 
-  tags = merge(module.tags.tages, {
+  tags = merge(module.tags.tags, {
     Name = local.domain
   })
 }
@@ -28,7 +28,7 @@ resource "cloudflare_dns_record" "dns_record_validation" {
   type    = element(module.acm_service.validation_domains, count.index)["resource_record_type"]
   ttl     = 300
 
-  content = trimsuffix(element(module.acm_service.validation_domains, count.index)["resource_record_name"], ".")
+  content = trimsuffix(element(module.acm_service.validation_domains, count.index)["resource_record_values"], ".")
   comment = "ACM DNS validation for ${local.domain} - ${element(module.acm_service.validation_domains, count.index)["resource_record_type"]}"
 
   proxied = false


### PR DESCRIPTION
This pull request introduces a new `acm_service` module to manage ACM certificates and their DNS validation records using Terraform. The changes streamline certificate management and improve the automation of DNS validation.

### ACM Certificate Management:

* Added a new `acm_service` module (`terraform-aws-modules/acm/aws`) to provision ACM certificates with support for a primary domain and multiple subject alternative names (`aws/acm_service.tf`, [aws/acm_service.tfR1-R35](diffhunk://#diff-b3723f34d9cfc7e24e13dbc3aae4f026bae21aba53fd64f7c670be1117be6eb6R1-R35)).

### DNS Validation:

* Added a `cloudflare_dns_record` resource to automate DNS validation for ACM certificates by creating the necessary DNS records in Cloudflare (`aws/acm_service.tf`, [aws/acm_service.tfR1-R35](diffhunk://#diff-b3723f34d9cfc7e24e13dbc3aae4f026bae21aba53fd64f7c670be1117be6eb6R1-R35)).