### PR TITLE
MTD-03[DevOps]:Adding-CAA-records

### DIFF
--- a/aws/cloudflare_dns_records.tf
+++ b/aws/cloudflare_dns_records.tf
@@ -21,7 +21,7 @@ resource "cloudflare_dns_record" "caa_acm_amazon_trust_issuer" {
   ttl  = 300
 
   data = {
-    tag   = "issue"
+    tag   = "issuewild"
     value = "amazontrust.com"
   }
 

--- a/aws/cloudflare_dns_records.tf
+++ b/aws/cloudflare_dns_records.tf
@@ -1,0 +1,25 @@
+resource "cloudflare_dns_record" "caa_acm_amazon_issuer" {
+  zone_id = local.cloudflare_zone_id
+  type    = "CAA"
+  ttl     = 300
+
+  data = {
+    tag   = "issue"
+    value = "amazon.com"
+  }
+
+  comment = "CAA record for ACM to issue certificates from Amazon"
+}
+
+resource "cloudflare_dns_record" "caa_acm_amazon_trust_issuer" {
+  zone_id = local.cloudflare_zone_id
+  type    = "CAA"
+  ttl     = 300
+
+  data = {
+    tag   = "issue"
+    value = "amazontrust.com"
+  }
+
+  comment = "CAA record for ACM to issue wildcard certificates from Amazon Trust Services"
+}

--- a/aws/cloudflare_dns_records.tf
+++ b/aws/cloudflare_dns_records.tf
@@ -1,7 +1,9 @@
 resource "cloudflare_dns_record" "caa_acm_amazon_issuer" {
   zone_id = local.cloudflare_zone_id
-  type    = "CAA"
-  ttl     = 300
+
+  name = local.domain
+  type = "CAA"
+  ttl  = 300
 
   data = {
     tag   = "issue"
@@ -13,8 +15,10 @@ resource "cloudflare_dns_record" "caa_acm_amazon_issuer" {
 
 resource "cloudflare_dns_record" "caa_acm_amazon_trust_issuer" {
   zone_id = local.cloudflare_zone_id
-  type    = "CAA"
-  ttl     = 300
+
+  name = local.domain
+  type = "CAA"
+  ttl  = 300
 
   data = {
     tag   = "issue"


### PR DESCRIPTION
This pull request adds two new Cloudflare DNS records to support ACM (AWS Certificate Manager) in issuing certificates. These changes ensure that ACM can issue both standard and wildcard certificates through Amazon and Amazon Trust Services.

### DNS configuration updates:

* Added a `cloudflare_dns_record` resource for a CAA record allowing ACM to issue certificates from `amazon.com`. (`aws/cloudflare_dns_records.tf`, [aws/cloudflare_dns_records.tfR1-R25](diffhunk://#diff-b8e376d9e2e539d088cc714cb8cfc4356611b05e9cab230b4ff2afef8c0cbc48R1-R25))
* Added a `cloudflare_dns_record` resource for a CAA record allowing ACM to issue wildcard certificates from `amazontrust.com`. (`aws/cloudflare_dns_records.tf`, [aws/cloudflare_dns_records.tfR1-R25](diffhunk://#diff-b8e376d9e2e539d088cc714cb8cfc4356611b05e9cab230b4ff2afef8c0cbc48R1-R25))