### PR TITLE
MTD-05[DevOps]:Adding-cname-dns-records

### DIFF
--- a/aws/cloudflare_dns_records_services.tf
+++ b/aws/cloudflare_dns_records_services.tf
@@ -1,0 +1,33 @@
+locals {
+  domain_list = [
+    "www",
+    "api",
+    "app"
+  ]
+}
+
+resource "cloudflare_dns_record" "dns_record_base_domain" {
+  zone_id = local.cloudflare_zone_id
+  name    = local.domain
+  type    = "CNAME"
+  ttl     = 300
+
+  content = kubernetes_ingress_v1.ingress_service.status.0.load_balancer.0.ingress.0.hostname
+  tags    = ["environment:${local.environment}", "type:frontend"]
+
+  depends_on = [kubernetes_ingress_v1.ingress_service]
+}
+
+resource "cloudflare_dns_record" "subdomain_records" {
+  for_each = toset(local.domain_list)
+
+  zone_id = local.cloudflare_zone_id
+  name    = "${each.key}.${local.domain}"
+  type    = "CNAME"
+  ttl     = 300
+
+  content = kubernetes_ingress_v1.ingress_service.status.0.load_balancer.0.ingress.0.hostname
+  tags    = ["environment:${local.environment}", contains(each.key, "api") ? "type:backend" : "type:frontend"]
+
+  depends_on = [kubernetes_ingress_v1.ingress_service]
+}


### PR DESCRIPTION
This pull request introduces new Terraform resources to manage Cloudflare DNS records dynamically for both base and subdomains. The changes aim to streamline DNS management by leveraging Terraform's capabilities for automation and consistency.

### Cloudflare DNS Record Management:

* **Added local variable `domain_list`**: Defined a list of subdomains (`www`, `api`, `app`) for dynamic DNS record creation. (`aws/cloudflare_dns_records_services.tf`, [aws/cloudflare_dns_records_services.tfR1-R33](diffhunk://#diff-e2d64bfb6b2c77d03a2da25b7ce92a32d50f4bfb66621237a855b42fc9fff3d3R1-R33))
* **Created `cloudflare_dns_record` resource for base domain**: Configured a CNAME record for the base domain, pointing to the Kubernetes ingress service hostname. Includes tags for environment and type. (`aws/cloudflare_dns_records_services.tf`, [aws/cloudflare_dns_records_services.tfR1-R33](diffhunk://#diff-e2d64bfb6b2c77d03a2da25b7ce92a32d50f4bfb66621237a855b42fc9fff3d3R1-R33))
* **Created `cloudflare_dns_record` resource for subdomains**: Used `for_each` to dynamically create CNAME records for each subdomain in the `domain_list`. Added conditional tagging to differentiate backend (`api`) from frontend subdomains. (`aws/cloudflare_dns_records_services.tf`, [aws/cloudflare_dns_records_services.tfR1-R33](diffhunk://#diff-e2d64bfb6b2c77d03a2da25b7ce92a32d50f4bfb66621237a855b42fc9fff3d3R1-R33))