### PR TITLE
Adding-Cert-Manager

### DIFF
--- a/gcp/google_certificate_manager.tf
+++ b/gcp/google_certificate_manager.tf
@@ -23,13 +23,13 @@ resource "google_certificate_manager_certificate" "cert_manager_root" {
 
 resource "google_certificate_manager_certificate_map" "cert_manager_map" {
     project = module.project.project_id
-    name = lower(join("-", local.domain,"cert", "manager", "map"))
+    name = lower(join("-", [local.domain, "cert", "manager", "map"]))
     description = "Certificate Map for ${local.domain} using Certificate Manager"
 }
 
 resource "google_certificate_manager_certificate_map_entry" "cert_manager_map_entry" {
     project = module.project.project_id
-    name = lower(join("-", local.domain,"cert", "manager", "map", "entry"))
+    name = lower(join("-", [local.domain, "cert", "manager", "map", "entry"]))
     description = "Certificate Map Entry for ${local.domain} using Certificate Manager"
     
     map = google_certificate_manager_certificate_map.cert_manager_map.id

--- a/gcp/google_certificate_manager.tf
+++ b/gcp/google_certificate_manager.tf
@@ -10,7 +10,7 @@ resource "google_certificate_manager_dns_authorization" "cert_manager_dns_author
 
 resource "google_certificate_manager_certificate" "cert_manager_root" {
     project = module.project.project_id
-    name = lower(join("-", local.domain,"cert", "manager", "root"))
+    name = lower(join("-", [local.domain, "cert", "manager", "root"]))
     description = "Wildcard Certificate for ${local.domain} using Certificate Manager"
     
     managed {

--- a/gcp/google_certificate_manager.tf
+++ b/gcp/google_certificate_manager.tf
@@ -1,0 +1,38 @@
+resource "google_certificate_manager_dns_authorization" "cert_manager_dns_authorization" {
+    project = module.project.project_id
+    name = lower(join("-", local.domain,"cert", "manager", "dns","auth"))
+
+    location = "global"
+    description = "DNS Authorization for Certificate Manager for ${local.domain}"
+    domain = local.domain
+  
+}
+
+resource "google_certificate_manager_certificate" "cert_manager_root" {
+    project = module.project.project_id
+    name = lower(join("-", local.domain,"cert", "manager", "root"))
+    description = "Wildcard Certificate for ${local.domain} using Certificate Manager"
+    
+    managed {
+        domains = [local.domain,
+        "*.${local.domain}"
+        ]
+        dns_authorizations = [ google_certificate_manager_dns_authorization.cert_manager_dns_authorization.id ]
+    }
+}
+
+resource "google_certificate_manager_certificate_map" "cert_manager_map" {
+    project = module.project.project_id
+    name = lower(join("-", local.domain,"cert", "manager", "map"))
+    description = "Certificate Map for ${local.domain} using Certificate Manager"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "cert_manager_map_entry" {
+    project = module.project.project_id
+    name = lower(join("-", local.domain,"cert", "manager", "map", "entry"))
+    description = "Certificate Map Entry for ${local.domain} using Certificate Manager"
+    
+    map = google_certificate_manager_certificate_map.cert_manager_map.id
+    certificates = [google_certificate_manager_certificate.cert_manager_root.id]
+    hostname = "*.${local.domain}"
+}

--- a/gcp/google_certificate_manager.tf
+++ b/gcp/google_certificate_manager.tf
@@ -1,6 +1,6 @@
 resource "google_certificate_manager_dns_authorization" "cert_manager_dns_authorization" {
     project = module.project.project_id
-    name = lower(join("-", local.domain,"cert", "manager", "dns","auth"))
+    name = lower(join("-", [local.domain, "cert", "manager", "dns", "auth"]))
 
     location = "global"
     description = "DNS Authorization for Certificate Manager for ${local.domain}"


### PR DESCRIPTION
This pull request introduces new resources to manage Google Cloud Certificate Manager configurations for automating SSL/TLS certificate provisioning and DNS authorization. The changes primarily focus on creating and linking resources for certificate management.

### Certificate Manager Configuration:

* Added `google_certificate_manager_dns_authorization` resource to handle DNS authorization for the specified domain.
* Added `google_certificate_manager_certificate` resource to create a managed wildcard certificate for the domain, utilizing the DNS authorization.
* Added `google_certificate_manager_certificate_map` resource to define a certificate map for organizing certificates.
* Added `google_certificate_manager_certificate_map_entry` resource to link the certificate to a hostname using the certificate map.